### PR TITLE
Fix assembly version

### DIFF
--- a/src/MMQ/Properties/AssemblyInfo.cs
+++ b/src/MMQ/Properties/AssemblyInfo.cs
@@ -20,3 +20,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f0d39a0d-7bf0-46ba-a7f3-6fed179922c4")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
The previous refactoring caused the AssemblyVersion and FileVersion attribute of the built dlls to be set to 0.0.0.0. This MR fixes this.